### PR TITLE
Updated README.md to include procrec in app list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Originally written by [Sam Clements], maintained by [Sam Clements], [Rob Day], a
 ## Apps using rust-psutil
 
 - [ytop](https://github.com/cjbassi/ytop)
+- [procrec](https://github.com/gh0st42/procrec)
 
 ## Related projects
 


### PR DESCRIPTION
I started to write a simple [process recorder and plotter](https://github.com/gh0st42/procrec) similar to the python app [psrecord](https://github.com/astrofrog/psrecord) using *rust* and *rust-psutil*

It currently works on macOS and Linux thanks to your library, plotting works by invoking `gnuplot` if it is installed. [procrec](https://github.com/gh0st42/procrec) does its job but is not very polished atm and not on crates.io (yet) due to the dependency on the unpublished version 3.0 of *clap*. 
