### PR TITLE
many little tweaks in the 'process' API

### DIFF
--- a/src/disk/filesystem.rs
+++ b/src/disk/filesystem.rs
@@ -80,10 +80,7 @@ pub enum FileSystem {
 impl FileSystem {
 	/// Checks if filesystem is used for a physical devices
 	pub fn is_physical(&self) -> bool {
-		match self {
-			FileSystem::Other(..) => false,
-			_ => true,
-		}
+		!matches!(self, FileSystem::Other(..))
 	}
 
 	/// Checks if filesystem is used for a virtual devices (such as `tmpfs` or `smb` mounts)

--- a/src/process/sys/macos/process.rs
+++ b/src/process/sys/macos/process.rs
@@ -161,7 +161,7 @@ impl Process {
 		todo!()
 	}
 
-	pub(crate) fn sys_chidren(&self) {
+	pub(crate) fn sys_children(&self) {
 		todo!()
 	}
 


### PR DESCRIPTION
This PR fixes the following:
- fix a spelling mistake: `Process::{chidren -> children}`
- fix the unwraps in `Process::sys_open_files`
- fix `clippy::match_like_matches_macro`
- process/`replace`: make `if` statement symetric to `is_*` methods

... and other miscellaneous things I found (mostly style, which is debatable)...