### PR TITLE
Fix macos process kinfo

### DIFF
--- a/src/process/os/macos/kinfo.rs
+++ b/src/process/os/macos/kinfo.rs
@@ -157,7 +157,11 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 			return Err(io::Error::last_os_error());
 		}
 
-		processes.reserve(size);
+		// Reserve enough room to store the whole process list
+		let num_processes = size / mem::size_of::<kinfo_proc>();
+		if num_processes > processes.capacity() {
+			processes.reserve_exact(num_processes - processes.capacity());
+		}
 
 		let result = unsafe {
 			libc::sysctl(

--- a/src/process/os/macos/kinfo.rs
+++ b/src/process/os/macos/kinfo.rs
@@ -181,7 +181,7 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 			// there was not enough space in `processes` to store the whole process list which can
 			// occur when a new process spawns between getting the size and storing. In this case
 			// we can simply try again.
-			if Some(libc::ENOMEM) = errno::errno() {
+			if libc::ENOMEM == errno::errno() {
 				continue;
 			} else {
 				return Err(io::Error::last_os_error());

--- a/src/process/os/macos/kinfo.rs
+++ b/src/process/os/macos/kinfo.rs
@@ -143,6 +143,7 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 	let mut processes: Vec<kinfo_proc> = vec![];
 
 	loop {
+		// Dry-run to get the size required for the process list
 		let result = unsafe {
 			libc::sysctl(
 				name.as_mut_ptr(),
@@ -163,6 +164,7 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 			processes.reserve_exact(num_processes - processes.capacity());
 		}
 
+		// Attempt to store the process list in `processes`
 		let result = unsafe {
 			libc::sysctl(
 				name.as_mut_ptr(),

--- a/src/process/os/macos/kinfo.rs
+++ b/src/process/os/macos/kinfo.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::ptr;
 
 use mach::{boolean, vm_types};
-use nix::libc;
+use nix::{errno, libc};
 
 use crate::process::{io_error_to_process_error, ProcessError, ProcessResult};
 use crate::Pid;
@@ -173,18 +173,26 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 				0,
 			)
 		};
-		match result {
-			libc::ENOMEM => continue,
-			code if code < 0 => return Err(io::Error::last_os_error()),
-			_ => {
-				let length = size / mem::size_of::<kinfo_proc>();
-				unsafe {
-					processes.set_len(length);
-				}
-				debug_assert!(!processes.is_empty());
 
-				return Ok(processes);
+		if result < 0 {
+			// Need to check to see if the error was due to `libc::ENOMEM`, this indicates that
+			// there was not enough space in `processes` to store the whole process list which can
+			// occur when a new process spawns between getting the size and storing. In this case
+			// we can simply try again.
+			if errno::errno() == libc::ENOMEM {
+				continue;
+			} else {
+				return Err(io::Error::last_os_error());
 			}
+		} else {
+			// Getting the list succeeded so let `processes` know how many processes it holds
+			let length = size / mem::size_of::<kinfo_proc>();
+			unsafe {
+				processes.set_len(length);
+			}
+			debug_assert!(!processes.is_empty());
+
+			return Ok(processes);
 		}
 	}
 }

--- a/src/process/os/macos/kinfo.rs
+++ b/src/process/os/macos/kinfo.rs
@@ -181,7 +181,7 @@ pub fn kinfo_processes() -> io::Result<Vec<kinfo_proc>> {
 			// there was not enough space in `processes` to store the whole process list which can
 			// occur when a new process spawns between getting the size and storing. In this case
 			// we can simply try again.
-			if errno::errno() == libc::ENOMEM {
+			if Some(libc::ENOMEM) = errno::errno() {
 				continue;
 			} else {
 				return Err(io::Error::last_os_error());


### PR DESCRIPTION
In cjbassi/ytop#75 some users, specifically on MacOS, were running into issues where `OsError { source: Os { code: 12, kind: Other, message: "Cannot allocate memory" } }` was being returned when trying to update the process list.

I eventually tracked this down to `kinfo_processes()` that had a couple of issues leading to this problem:

1. `reserve` will reserve an additional number of elements represented by the value passed in whereas here it was being given the expected size of all elements in bytes. This was resulting in much more space being reserved than was required.
2. Incorrectly checking for `ENOMEM`. Based on [this](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html) document:

> If the amount of data available is greater than the size of the buffer supplied, the call supplies as much data as fits in the buffer provided and returns with the error code `ENOMEM`.

However

> Upon successful completion, the value 0 is returned; otherwise the value -1 is returned and the global variable `errno` is set to indicate the error.

So I can understand the confusion from the wording, but when it mentions returning `ENOMEM` this is in the form of `errno`, not as the return value from the function call. This manifested where the code would check for `ENOMEM` from `sysctl` instead of `errno`, which would cause the error to bubble up instead of appropriately retrying. I think the large reserve size made this case easier to hit since it would stall for more time between reading for the required size and attempting to store.

I would appreciate a thorough look over the changes since it's pretty close to messing with `unsafe` code and I was able to reproduce the issue on MacOS, but didn't have a chance to verify that the changes work correctly.