### PR TITLE
Switch snafu to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 cfg-if = "0.1.10"
 nix = "0.17.0"
 once_cell = "1.2.0"
-snafu = "0.6.0"
+thiserror = "1.0.20"
 
 derive_more = { version = "0.99.2", optional = true, default-features = false, features = ["add", "sum"]}
 glob = { version = "0.3.0", optional = true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use glob::glob as other_glob;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ParseStatusError {
+pub enum ParseStatusError {
 	/// Linux only.
 	#[error("Length is not 1. Contents: '{}'", contents)]
 	IncorrectLength { contents: String },
@@ -19,7 +19,7 @@ pub(crate) enum ParseStatusError {
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
 	/// Linux only.
 	#[error("Failed to read file '{}': {}", path.display(), source)]
 	ReadFile { path: PathBuf, source: io::Error },

--- a/src/host/sys/linux/boot_time.rs
+++ b/src/host/sys/linux/boot_time.rs
@@ -31,7 +31,7 @@ pub fn boot_time() -> Result<SystemTime> {
 		.find(|line| line.starts_with("btime "))
 		.ok_or(Error::MissingData {
 			path: PROC_STAT.into(),
-			contents,
+			contents: contents.clone(),
 		})?;
 
 	parse_boot_time(line)

--- a/src/memory/sys/linux/common.rs
+++ b/src/memory/sys/linux/common.rs
@@ -1,27 +1,24 @@
 use std::collections::HashMap;
 
-use snafu::{ensure, ResultExt};
-
-use crate::{MissingData, ParseInt, Result};
+use crate::{Error, Result};
 
 // TODO: should we only parse the ints that we need?
 pub(crate) fn make_map<'a>(content: &'a str, path: &str) -> Result<HashMap<&'a str, u64>> {
 	content
 		.lines()
 		.map(|line| {
-			let fields: Vec<&str> = line.split_whitespace().collect();
+			let fields = match line.split_whitespace().collect::<Vec<_>>() {
+				fields if fields.len() >= 2 => Ok(fields),
+				_ => Err(Error::MissingData {
+					path: path.into(),
+					contents: line.to_string(),
+				}),
+			}?;
 
-			ensure!(
-				fields.len() >= 2,
-				MissingData {
-					path,
-					contents: line,
-				}
-			);
-
-			let mut parsed = fields[1].parse().context(ParseInt {
-				path,
-				contents: line,
+			let mut parsed = fields[1].parse().map_err(|err| Error::ParseInt {
+				path: path.into(),
+				contents: line.to_string(),
+				source: err,
 			})?;
 			// only needed for `/proc/meminfo`
 			if fields.len() >= 3 && fields[2] == "kB" {

--- a/src/memory/sys/linux/swap_memory.rs
+++ b/src/memory/sys/linux/swap_memory.rs
@@ -1,8 +1,6 @@
-use snafu::OptionExt;
-
 use crate::memory::{make_map, SwapMemory};
 use crate::utils::u64_percent;
-use crate::{read_file, MissingData, Result};
+use crate::{read_file, Error, Result};
 
 const PROC_MEMINFO: &str = "/proc/meminfo";
 const PROC_VMSTAT: &str = "/proc/vmstat";
@@ -16,15 +14,15 @@ pub fn swap_memory() -> Result<SwapMemory> {
 	let vmstat = make_map(&vmstat_contents, PROC_VMSTAT)?;
 
 	let meminfo_get = |key: &str| -> Result<u64> {
-		meminfo.get(key).copied().context(MissingData {
-			path: PROC_MEMINFO,
-			contents: &meminfo_contents,
+		meminfo.get(key).copied().ok_or(Error::MissingData {
+			path: PROC_MEMINFO.into(),
+			contents: meminfo_contents,
 		})
 	};
 	let vmstat_get = |key: &str| -> Result<u64> {
-		vmstat.get(key).copied().context(MissingData {
-			path: PROC_VMSTAT,
-			contents: &vmstat_contents,
+		vmstat.get(key).copied().ok_or(Error::MissingData {
+			path: PROC_VMSTAT.into(),
+			contents: vmstat_contents,
 		})
 	};
 

--- a/src/memory/sys/linux/swap_memory.rs
+++ b/src/memory/sys/linux/swap_memory.rs
@@ -16,13 +16,13 @@ pub fn swap_memory() -> Result<SwapMemory> {
 	let meminfo_get = |key: &str| -> Result<u64> {
 		meminfo.get(key).copied().ok_or(Error::MissingData {
 			path: PROC_MEMINFO.into(),
-			contents: meminfo_contents,
+			contents: meminfo_contents.clone(),
 		})
 	};
 	let vmstat_get = |key: &str| -> Result<u64> {
 		vmstat.get(key).copied().ok_or(Error::MissingData {
 			path: PROC_VMSTAT.into(),
-			contents: vmstat_contents,
+			contents: vmstat_contents.clone(),
 		})
 	};
 

--- a/src/memory/sys/linux/virtual_memory.rs
+++ b/src/memory/sys/linux/virtual_memory.rs
@@ -11,7 +11,7 @@ pub fn virtual_memory() -> Result<VirtualMemory> {
 	let get = |key: &str| -> Result<u64> {
 		meminfo.get(key).copied().ok_or(Error::MissingData {
 			path: PROC_MEMINFO.into(),
-			contents,
+			contents: contents.clone(),
 		})
 	};
 

--- a/src/memory/sys/linux/virtual_memory.rs
+++ b/src/memory/sys/linux/virtual_memory.rs
@@ -1,7 +1,5 @@
-use snafu::OptionExt;
-
 use crate::memory::{make_map, VirtualMemory};
-use crate::{read_file, MissingData, Result};
+use crate::{read_file, Error, Result};
 
 const PROC_MEMINFO: &str = "/proc/meminfo";
 
@@ -11,9 +9,9 @@ pub fn virtual_memory() -> Result<VirtualMemory> {
 	let meminfo = make_map(&contents, PROC_MEMINFO)?;
 
 	let get = |key: &str| -> Result<u64> {
-		meminfo.get(key).copied().context(MissingData {
-			path: PROC_MEMINFO,
-			contents: &contents,
+		meminfo.get(key).copied().ok_or(Error::MissingData {
+			path: PROC_MEMINFO.into(),
+			contents,
 		})
 	};
 

--- a/src/process/errors.rs
+++ b/src/process/errors.rs
@@ -6,7 +6,7 @@ pub type ProcessResult<T> = std::result::Result<T, ProcessError>;
 
 // TODO: get this visibility junk sorted out
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ProcessError {
+pub enum ProcessError {
 	#[error("Process {} does not exists", pid)]
 	NoSuchProcess { pid: Pid },
 

--- a/src/process/errors.rs
+++ b/src/process/errors.rs
@@ -1,24 +1,22 @@
 use std::io;
 
-use snafu::Snafu;
-
 use crate::{Error, Pid};
 
 pub type ProcessResult<T> = std::result::Result<T, ProcessError>;
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub(crate)))]
-pub enum ProcessError {
-	#[snafu(display("Process {} does not exists", pid))]
+// TODO: get this visibility junk sorted out
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ProcessError {
+	#[error("Process {} does not exists", pid)]
 	NoSuchProcess { pid: Pid },
 
-	#[snafu(display("Process {} is a zombie", pid))]
+	#[error("Process {} is a zombie", pid)]
 	ZombieProcess { pid: Pid },
 
-	#[snafu(display("Access denied for process {}", pid))]
+	#[error("Access denied for process {}", pid)]
 	AccessDenied { pid: Pid },
 
-	#[snafu(display("psutil error for process {}: {}", pid, source))]
+	#[error("psutil error for process {}: {}", pid, source)]
 	PsutilError { pid: Pid, source: Error },
 }
 

--- a/src/process/errors.rs
+++ b/src/process/errors.rs
@@ -4,7 +4,6 @@ use crate::{Error, Pid};
 
 pub type ProcessResult<T> = std::result::Result<T, ProcessError>;
 
-// TODO: get this visibility junk sorted out
 #[derive(Debug, thiserror::Error)]
 pub enum ProcessError {
 	#[error("Process {} does not exists", pid)]

--- a/src/process/os/linux/procfs/status.rs
+++ b/src/process/os/linux/procfs/status.rs
@@ -56,16 +56,19 @@ impl FromStr for ProcfsStatus {
 			})
 		};
 
-		let missing_data = Error::MissingData {
-			path: STATUS.into(),
-			contents: contents.to_string(),
+		let get = |key: &str| -> Result<&str> {
+			map.get(key).copied().ok_or(Error::MissingData {
+				path: STATUS.into(),
+				contents: contents.to_string(),
+			})
 		};
-
-		let get = |key: &str| -> Result<&str> { map.get(key).copied().ok_or(missing_data) };
 
 		let uid_fields = match get("Uid")?.split_whitespace().collect::<Vec<_>>() {
 			fields if fields.len() >= 4 => Ok(fields),
-			_ => Err(missing_data),
+			_ => Err(Error::MissingData {
+				path: STATUS.into(),
+				contents: contents.to_string(),
+			}),
 		}?;
 
 		let uid = [
@@ -77,7 +80,10 @@ impl FromStr for ProcfsStatus {
 
 		let gid_fields = match get("Gid")?.split_whitespace().collect::<Vec<_>>() {
 			fields if fields.len() >= 4 => Ok(fields),
-			_ => Err(missing_data),
+			_ => Err(Error::MissingData {
+				path: STATUS.into(),
+				contents: contents.to_string(),
+			}),
 		}?;
 
 		let gid = [

--- a/src/process/sys/linux/status.rs
+++ b/src/process/sys/linux/status.rs
@@ -1,10 +1,8 @@
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-use snafu::ensure;
-
 use crate::process::Status;
-use crate::{IncorrectLength, ParseStatusError};
+use crate::ParseStatusError;
 
 /// Returns a Status based on a status character from `/proc/[pid]/stat`.
 ///
@@ -39,7 +37,11 @@ impl FromStr for Status {
 	type Err = ParseStatusError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		ensure!(s.len() == 1, IncorrectLength { contents: s });
+		if s.len() == 1 {
+			return Err(ParseStatusError::IncorrectLength {
+				contents: s.to_string(),
+			});
+		}
 
 		Status::try_from(s.chars().next().unwrap())
 	}

--- a/src/process/sys/linux/status.rs
+++ b/src/process/sys/linux/status.rs
@@ -37,13 +37,13 @@ impl FromStr for Status {
 	type Err = ParseStatusError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		if s.len() == 1 {
-			return Err(ParseStatusError::IncorrectLength {
+		if s.len() != 1 {
+			Err(ParseStatusError::IncorrectLength {
 				contents: s.to_string(),
-			});
+			})
+		} else {
+			Status::try_from(s.chars().next().unwrap())
 		}
-
-		Status::try_from(s.chars().next().unwrap())
 	}
 }
 

--- a/src/process/sys/linux/status.rs
+++ b/src/process/sys/linux/status.rs
@@ -38,12 +38,12 @@ impl FromStr for Status {
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		if s.len() != 1 {
-			Err(ParseStatusError::IncorrectLength {
+			return Err(ParseStatusError::IncorrectLength {
 				contents: s.to_string(),
-			})
-		} else {
-			Status::try_from(s.chars().next().unwrap())
+			});
 		}
+
+		Status::try_from(s.chars().next().unwrap())
 	}
 }
 


### PR DESCRIPTION
This is an experimental switch to `thiserror` `from` `snafu` (following #71). The good news is this drops compile times, from `cargo bloat -j 1 --time --release` it went from a total of 156.58 to 93.16 which is a pretty significant drop (on my `Intel i5-5200U @ 2.7GHz` CPU). I would double check everything to make sure anything is different.