### PR TITLE
Make all public types serde Serializable and Deserializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num_cpus = { version = "1.11.1", optional = true }
 platforms = { version = "0.2.1", optional = true }
 signal = { version = "0.7.0", optional = true }
 unescape = { version = "0.1.0", optional = true }
+renamed_serde = { version = "1.0", optional = true, package = "serde", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 darwin-libproc = { version = "0.1.1", optional = true }
@@ -36,6 +37,7 @@ memory = ["mach"]
 network = ["derive_more"]
 process = ["darwin-libproc", "mach", "memory"]
 sensors = ["glob"]
+serde = ["renamed_serde", "platforms/serde"]
 
 [dev-dependencies]
 float-cmp = "0.6.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TcpConnectionStatus {
 	Established,
 	SynSent,
@@ -18,6 +23,8 @@ pub enum TcpConnectionStatus {
 	Bound,
 }
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NetConnectionType {
 	Inet,
 	Inet4,

--- a/src/cpu/cpu_freq.rs
+++ b/src/cpu/cpu_freq.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Mhz;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CpuFreq {}
 
 impl CpuFreq {

--- a/src/cpu/cpu_stats.rs
+++ b/src/cpu/cpu_stats.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Count;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CpuStats {}
 
 impl CpuStats {

--- a/src/cpu/cpu_times.rs
+++ b/src/cpu/cpu_times.rs
@@ -1,7 +1,12 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::ops::Sub;
 use std::time::Duration;
 
 /// Every attribute represents the seconds the CPU has spent in the given mode.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CpuTimes {
 	pub(crate) user: Duration,

--- a/src/cpu/cpu_times_percent.rs
+++ b/src/cpu/cpu_times_percent.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::time::Duration;
 
 use crate::cpu::{cpu_times, cpu_times_percpu, CpuTimes};
@@ -5,6 +8,8 @@ use crate::utils::duration_percent;
 use crate::{Percent, Result};
 
 /// Every attribute represents the percentage of time the CPU has spent in the given mode.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct CpuTimesPercent {
 	pub(crate) user: Percent,

--- a/src/disk/disk_io_counters.rs
+++ b/src/disk/disk_io_counters.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -6,6 +9,8 @@ use derive_more::{Add, Sub, Sum};
 use crate::disk::disk_io_counters_per_partition;
 use crate::{Bytes, Count, Result};
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Add, Sum, Default, Sub)]
 pub struct DiskIoCounters {
 	pub(crate) read_count: Count,

--- a/src/disk/filesystem.rs
+++ b/src/disk/filesystem.rs
@@ -1,11 +1,16 @@
 // https://github.com/heim-rs/heim/blob/master/heim-disk/src/filesystem.rs
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::str::FromStr;
 
 /// Known filesystems.
 ///
 /// All physical filesystems should have their own enum element
 /// and all virtual filesystems will go into the `Other` element.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum FileSystem {
 	/// ext2 (https://en.wikipedia.org/wiki/Ext2)

--- a/src/disk/partition.rs
+++ b/src/disk/partition.rs
@@ -1,8 +1,13 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::path::{Path, PathBuf};
 
 use crate::disk::{partitions, FileSystem};
 use crate::Result;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Partition {
 	pub(crate) device: String,

--- a/src/host/info.rs
+++ b/src/host/info.rs
@@ -1,6 +1,11 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use platforms::target::{Arch, OS};
 
 /// Not found in Python psutil.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Info {
 	pub(crate) operating_system: OS,

--- a/src/host/loadavg.rs
+++ b/src/host/loadavg.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::FloatCount;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct LoadAvg {
 	/// Number of jobs in the run queue averaged over 1 minute.

--- a/src/host/user.rs
+++ b/src/host/user.rs
@@ -1,7 +1,12 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::time::SystemTime;
 
 use crate::Pid;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct User {}
 
 impl User {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 //!     - enums instead of constants
 //! - most struct fields have been replaced with getter methods to better enable platform based extensions
 
+#[cfg(feature = "serde")]
+extern crate renamed_serde as serde;
+
 #[macro_use]
 mod utils;
 pub mod common;

--- a/src/memory/swap_memory.rs
+++ b/src/memory/swap_memory.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{Bytes, Percent};
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct SwapMemory {
 	pub(crate) total: Bytes,

--- a/src/memory/virtual_memory.rs
+++ b/src/memory/virtual_memory.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{Bytes, Percent};
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct VirtualMemory {
 	pub(crate) total: Bytes,

--- a/src/network/net_connection.rs
+++ b/src/network/net_connection.rs
@@ -1,6 +1,11 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::TcpConnectionStatus;
 use crate::{Fd, Pid};
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NetConnection {}
 
 impl NetConnection {

--- a/src/network/net_if_addr.rs
+++ b/src/network/net_if_addr.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::net::IpAddr;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NetIfAddr {}
 
 impl NetIfAddr {

--- a/src/network/net_if_stats.rs
+++ b/src/network/net_if_stats.rs
@@ -1,11 +1,18 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Bytes;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Duplex {
 	Full,
 	Half,
 	Unknown,
 }
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NetIfStats {}
 
 impl NetIfStats {

--- a/src/network/net_io_couters.rs
+++ b/src/network/net_io_couters.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::collections::HashMap;
 
 use derive_more::{Add, Sub, Sum};
@@ -5,6 +8,8 @@ use derive_more::{Add, Sub, Sum};
 use crate::network::net_io_counters_pernic;
 use crate::{Bytes, Count, Result};
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Add, Sum, Sub)]
 pub struct NetIoCounters {
 	pub(crate) bytes_sent: Bytes,

--- a/src/process/collector.rs
+++ b/src/process/collector.rs
@@ -1,8 +1,14 @@
+// #[cfg(feature = "serde")]
+// use serde::{Deserialize, Serialize};
+
 use std::collections::BTreeMap;
 
 use crate::process::{self, Process};
 use crate::{Pid, Result};
-
+// FIXME: Process cannot be serialized/deserialize, as a result,
+//        neither this can be.
+// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ProcessCollector {
 	pub processes: BTreeMap<Pid, Process>,

--- a/src/process/cpu_times.rs
+++ b/src/process/cpu_times.rs
@@ -1,10 +1,14 @@
 // https://github.com/heim-rs/heim/blob/master/heim-process/src/sys/macos/process/cpu_times.rs
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use std::time::Duration;
 
 #[cfg(target_os = "linux")]
 use crate::process::os::linux::ProcfsStat;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct ProcessCpuTimes {
 	pub(crate) user: Duration,

--- a/src/process/memory.rs
+++ b/src/process/memory.rs
@@ -1,4 +1,6 @@
 // https://github.com/heim-rs/heim/blob/master/heim-process/src/sys/macos/process/memory.rs
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::Bytes;
 
@@ -7,10 +9,14 @@ use crate::process::os::linux::ProcfsStatm;
 #[cfg(target_os = "macos")]
 use crate::Count;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MemType {
 	// TODO
 }
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MemoryInfo {
 	pub(crate) rss: Bytes,

--- a/src/process/open_file.rs
+++ b/src/process/open_file.rs
@@ -1,7 +1,12 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::path::PathBuf;
 
 use crate::Fd;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OpenFile {
 	pub path: PathBuf,
 	pub fd: Option<Fd>,

--- a/src/process/os/linux/procfs/stat.rs
+++ b/src/process/os/linux/procfs/stat.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -9,6 +12,8 @@ use crate::{read_file, Error, MissingData, ParseInt, Pid, Result, PAGE_SIZE, TIC
 const STAT: &str = "stat";
 
 /// New struct, not in Python psutil.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct ProcfsStat {
 	/// PID of the process.

--- a/src/process/process.rs
+++ b/src/process/process.rs
@@ -1,3 +1,6 @@
+// #[cfg(feature = "serde")]
+// use serde::{Deserialize, Serialize};
+
 use std::cmp;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -20,11 +23,15 @@ use crate::{Count, Percent, Pid};
 #[cfg(target_os = "linux")]
 use crate::process::os::linux::ProcfsStat;
 
+// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Process {
 	pub(crate) pid: Pid,
 	pub(crate) create_time: Duration,
 	pub(crate) busy: Duration,
+	// FIXME: Instant does not serialize/deserialize, cannot add serde
+	// #[cfg_attr(feature = "serde", serde(skip))]
 	pub(crate) instant: Instant,
 
 	#[cfg(target_os = "linux")]

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -1,4 +1,9 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Possible statuses for a process.
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug)]
 pub enum Status {
 	/// (R)

--- a/src/sensors/fan_sensor.rs
+++ b/src/sensors/fan_sensor.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Rpm;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FanSensor {
 	pub(crate) _label: String,
 	pub(crate) _current: Rpm,

--- a/src/sensors/temperature_sensor.rs
+++ b/src/sensors/temperature_sensor.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Temperature;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct TemperatureSensor {
 	pub(crate) unit: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub type Fd = u32;
 pub type Pid = u32;
 
@@ -11,6 +14,8 @@ pub type FloatCount = f64;
 pub type Degrees = FloatCount;
 pub type Mhz = FloatCount;
 
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Temperature {
 	celsius: Degrees,


### PR DESCRIPTION
Closes #83

The serde dependency needed to be renamed so that we can name a
feature with the same name: serde. We needed this because we needed
to pass down the serde feature to the platforms crate when it is
activated. From Cargo documentation, features cannot be named the
same as any dependency crate, you cannot have a feature named serde
if you depend on a crate also named serde. You can however rename
that crate, use the package option so that the right crate is still
fetched from crates.io, and then create your feature with the name.

Additionally, we needed to inform serde derive machinery of the new
crate name, and using `extern crate renamed_serde as serde` is not
sufficient and somehow the rename is not passed down. I could find
an issue about this: https://github.com/serde-rs/serde/issues/1855
it looks like the same problem, or close. To do that we needed to
add one additional serde attribute at every place derive is used.

All this ended up being quite complex and I think something has to
be done in Cargo, rustc or serde to make it easier.