### PR TITLE
process: fix error typo

### DIFF
--- a/src/process/errors.rs
+++ b/src/process/errors.rs
@@ -6,7 +6,7 @@ pub type ProcessResult<T> = std::result::Result<T, ProcessError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProcessError {
-	#[error("Process {} does not exists", pid)]
+	#[error("Process {} does not exist", pid)]
 	NoSuchProcess { pid: Pid },
 
 	#[error("Process {} is a zombie", pid)]


### PR DESCRIPTION
Fix typo: "does not exists" to "does not exist".

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>