### PR TITLE
Upgrade nix dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.10"
-nix = "0.17.0"
+nix = "0.20.0"
 once_cell = "1.2.0"
 thiserror = "1.0.20"
 


### PR DESCRIPTION
This might require a major version bump, since `nix::Error` is part of the public API.
