### PR TITLE
Upgrade to nix 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1.0.0"
-nix = "0.23.0"
+nix = { version = "0.24.1", default-features = false, features = ["feature", "fs", "signal"] }
 once_cell = "1.2.0"
 thiserror = "1.0.20"
 

--- a/src/host/sys/unix/info.rs
+++ b/src/host/sys/unix/info.rs
@@ -8,13 +8,21 @@ use platforms::target::{Arch, OS};
 use crate::host::Info;
 
 pub fn info() -> Info {
-	let utsname = sys::utsname::uname();
+	let utsname = sys::utsname::uname().unwrap();
 
-	let operating_system = OS::from_str(utsname.sysname()).unwrap_or(OS::Unknown);
-	let release = utsname.release().to_string();
-	let version = utsname.version().to_string();
-	let hostname = utsname.nodename().to_string();
-	let architecture = Arch::from_str(utsname.machine()).unwrap_or(Arch::Unknown);
+	let operating_system = utsname
+		.sysname()
+		.to_str()
+		.and_then(|s| OS::from_str(s).ok())
+		.unwrap_or(OS::Unknown);
+	let release = utsname.release().to_str().unwrap_or_default().to_string();
+	let version = utsname.version().to_str().unwrap_or_default().to_string();
+	let hostname = utsname.nodename().to_str().unwrap_or_default().to_string();
+	let architecture = utsname
+		.machine()
+		.to_str()
+		.and_then(|s| Arch::from_str(s).ok())
+		.unwrap_or(Arch::Unknown);
 
 	Info {
 		operating_system,


### PR DESCRIPTION
Limiting features removes memoffset as an indirect dependency, and should slightly decrease compile times.

nix 0.24 now correctly reports that uname() can fail, and that the returned fields are not guaranteed to be valid UTF-8.
Handle these by panicking if uname() fails (which should not happen), and reporting an empty string for invalid UTF-8.