### PR TITLE
Fix ProcessCpuTimes on macOS arm64 (Apple Silicon)

### DIFF
--- a/src/process/cpu_times.rs
+++ b/src/process/cpu_times.rs
@@ -7,6 +7,21 @@ use std::time::Duration;
 #[cfg(target_os = "linux")]
 use crate::process::os::linux::ProcfsStat;
 
+#[cfg(target_os = "macos")]
+pub(crate) static MACH_TIMEBASE_INFO: once_cell::sync::Lazy<mach::mach_time::mach_timebase_info> =
+	once_cell::sync::Lazy::new(|| {
+		let mut timebase_info = mach::mach_time::mach_timebase_info { numer: 0, denom: 0 };
+		let timebase_info_result =
+			unsafe { mach::mach_time::mach_timebase_info(&mut timebase_info) };
+		if timebase_info_result != mach::kern_return::KERN_SUCCESS {
+			panic!(
+				"mach_timebase_info failed: {}",
+				std::io::Error::last_os_error()
+			)
+		}
+		timebase_info
+	});
+
 #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
@@ -60,8 +75,14 @@ impl From<&ProcfsStat> for ProcessCpuTimes {
 impl From<darwin_libproc::proc_taskinfo> for ProcessCpuTimes {
 	fn from(info: darwin_libproc::proc_taskinfo) -> Self {
 		ProcessCpuTimes {
-			user: Duration::from_nanos(info.pti_total_user),
-			system: Duration::from_nanos(info.pti_total_system),
+			user: Duration::from_nanos(
+				(info.pti_total_user as u64 * MACH_TIMEBASE_INFO.numer as u64)
+					/ MACH_TIMEBASE_INFO.denom as u64,
+			),
+			system: Duration::from_nanos(
+				(info.pti_total_system as u64 * MACH_TIMEBASE_INFO.numer as u64)
+					/ MACH_TIMEBASE_INFO.denom as u64,
+			),
 			children_user: Duration::default(),
 			children_system: Duration::default(),
 		}


### PR DESCRIPTION
`proc_taskinfo` returns user and system time in mach tick units, not in
nanoseconds. On Intel machines, the mapping of mach tick units to
nanoseconds is 1/1. On Apple Silicon it is 3/125th. This constant can be
retrieved using `mach_timebase_info`.

https://developer.apple.com/documentation/driverkit/3433733-mach_timebase_info

A similar fix in htop: https://github.com/htop-dev/htop/pull/752
