### PR TITLE
Expose `shared` memory value from `MemoryInfo`

### DIFF
--- a/src/process/memory.rs
+++ b/src/process/memory.rs
@@ -44,6 +44,11 @@ impl MemoryInfo {
 	pub fn vms(&self) -> Bytes {
 		self.vms
 	}
+
+	#[cfg(target_os = "linux")]
+	pub fn shared(&self) -> Bytes {
+		self.shared
+	}
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
The `shared` field is currently `pub(crate)` and not exposed. This PR adds a getter method to allow access this the shared memory value.