### PR TITLE
Update doc comments in Disk Usage

### DIFF
--- a/src/disk/sys/unix/disk_usage.rs
+++ b/src/disk/sys/unix/disk_usage.rs
@@ -18,12 +18,12 @@ impl DiskUsage {
 		self.total
 	}
 
-	/// Number of bytes used.
+	/// Number of bytes used in Disk.
 	pub fn used(&self) -> Bytes {
 		self.used
 	}
 
-	/// Number of bytes free.
+	/// Number of bytes free in Disk.
 	pub fn free(&self) -> Bytes {
 		self.free
 	}


### PR DESCRIPTION
Spent a good bit of time to understand that this is the amount of disk free in disk. when looking at the api disk_usage(path), i wasn't sure if it had something to do with the path. Since 2 paths in the same mount will return the same result, it makes sense to update the comments to let folks know that this is independent of path