### PR TITLE
Fixed: OS::from_str failing to parse the operating system correctly due to case sensitivity.

### DIFF
--- a/src/host/sys/unix/info.rs
+++ b/src/host/sys/unix/info.rs
@@ -13,7 +13,7 @@ pub fn info() -> Info {
 	let operating_system = utsname
 		.sysname()
 		.to_str()
-		.and_then(|s| OS::from_str(s).ok())
+		.and_then(|s| OS::from_str(s.to_lowercase().as_str()).ok())
 		.unwrap_or(OS::Unknown);
 	let release = utsname.release().to_str().unwrap_or_default().to_string();
 	let version = utsname.version().to_str().unwrap_or_default().to_string();


### PR DESCRIPTION
Ensure OS::from_str correctly parses the operating system by normalizing case.