### PR TITLE
fix: reorder serde attributes to follow compiler rule #79202

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub enum TcpConnectionStatus {
 	Established,
 	SynSent,
@@ -23,8 +23,8 @@ pub enum TcpConnectionStatus {
 	Bound,
 }
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub enum NetConnectionType {
 	Inet,
 	Inet4,

--- a/src/cpu/cpu_freq.rs
+++ b/src/cpu/cpu_freq.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::Mhz;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct CpuFreq {
 	current: Mhz,
 	min: Mhz,

--- a/src/cpu/cpu_stats.rs
+++ b/src/cpu/cpu_stats.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::Count;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct CpuStats {}
 
 impl CpuStats {

--- a/src/cpu/cpu_times.rs
+++ b/src/cpu/cpu_times.rs
@@ -5,8 +5,8 @@ use std::ops::Sub;
 use std::time::Duration;
 
 /// Every attribute represents the seconds the CPU has spent in the given mode.
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CpuTimes {
 	pub(crate) user: Duration,

--- a/src/cpu/cpu_times_percent.rs
+++ b/src/cpu/cpu_times_percent.rs
@@ -8,8 +8,8 @@ use crate::utils::duration_percent;
 use crate::{Percent, Result};
 
 /// Every attribute represents the percentage of time the CPU has spent in the given mode.
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct CpuTimesPercent {
 	pub(crate) user: Percent,

--- a/src/disk/disk_io_counters.rs
+++ b/src/disk/disk_io_counters.rs
@@ -9,8 +9,8 @@ use derive_more::{Add, Sub, Sum};
 use crate::disk::disk_io_counters_per_partition;
 use crate::{Bytes, Count, Result};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug, Add, Sum, Default, Sub)]
 pub struct DiskIoCounters {
 	pub(crate) read_count: Count,

--- a/src/disk/filesystem.rs
+++ b/src/disk/filesystem.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 ///
 /// All physical filesystems should have their own enum element
 /// and all virtual filesystems will go into the `Other` element.
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[non_exhaustive]
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum FileSystem {

--- a/src/disk/partition.rs
+++ b/src/disk/partition.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use crate::disk::{partitions, FileSystem};
 use crate::Result;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug)]
 pub struct Partition {
 	pub(crate) device: String,

--- a/src/host/info.rs
+++ b/src/host/info.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use platforms::target::{Arch, OS};
 
 /// Not found in Python psutil.
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug)]
 pub struct Info {
 	pub(crate) operating_system: OS,

--- a/src/host/loadavg.rs
+++ b/src/host/loadavg.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::FloatCount;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug)]
 pub struct LoadAvg {
 	/// Number of jobs in the run queue averaged over 1 minute.

--- a/src/host/user.rs
+++ b/src/host/user.rs
@@ -5,8 +5,8 @@ use std::time::SystemTime;
 
 use crate::Pid;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct User {}
 
 impl User {

--- a/src/memory/swap_memory.rs
+++ b/src/memory/swap_memory.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Bytes, Percent};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone)]
 pub struct SwapMemory {
 	pub(crate) total: Bytes,

--- a/src/memory/virtual_memory.rs
+++ b/src/memory/virtual_memory.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Bytes, Percent};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone)]
 pub struct VirtualMemory {
 	pub(crate) total: Bytes,

--- a/src/network/net_connection.rs
+++ b/src/network/net_connection.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::common::TcpConnectionStatus;
 use crate::{Fd, Pid};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct NetConnection {}
 
 impl NetConnection {

--- a/src/network/net_if_addr.rs
+++ b/src/network/net_if_addr.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use std::net::IpAddr;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct NetIfAddr {}
 
 impl NetIfAddr {

--- a/src/network/net_if_stats.rs
+++ b/src/network/net_if_stats.rs
@@ -3,16 +3,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::Bytes;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub enum Duplex {
 	Full,
 	Half,
 	Unknown,
 }
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct NetIfStats {}
 
 impl NetIfStats {

--- a/src/network/net_io_couters.rs
+++ b/src/network/net_io_couters.rs
@@ -8,8 +8,8 @@ use derive_more::{Add, Sub, Sum};
 use crate::network::net_io_counters_pernic;
 use crate::{Bytes, Count, Result};
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug, Add, Sum, Sub)]
 pub struct NetIoCounters {
 	pub(crate) bytes_sent: Bytes,

--- a/src/process/collector.rs
+++ b/src/process/collector.rs
@@ -7,8 +7,8 @@ use crate::process::{self, Process};
 use crate::{Pid, Result};
 // FIXME: Process cannot be serialized/deserialize, as a result,
 //        neither this can be.
-// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 // #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone)]
 pub struct ProcessCollector {
 	pub processes: BTreeMap<Pid, Process>,

--- a/src/process/cpu_times.rs
+++ b/src/process/cpu_times.rs
@@ -22,8 +22,8 @@ pub(crate) static MACH_TIMEBASE_INFO: once_cell::sync::Lazy<mach2::mach_time::ma
 		timebase_info
 	});
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug)]
 pub struct ProcessCpuTimes {
 	pub(crate) user: Duration,

--- a/src/process/memory.rs
+++ b/src/process/memory.rs
@@ -9,15 +9,15 @@ use crate::process::os::linux::ProcfsStatm;
 #[cfg(target_os = "macos")]
 use crate::Count;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub enum MemType {
 	// TODO
 }
 
 #[allow(dead_code)]
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone)]
 pub struct MemoryInfo {
 	pub(crate) rss: Bytes,

--- a/src/process/open_file.rs
+++ b/src/process/open_file.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use crate::Fd;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct OpenFile {
 	pub path: PathBuf,
 	pub fd: Option<Fd>,

--- a/src/process/os/linux/procfs/stat.rs
+++ b/src/process/os/linux/procfs/stat.rs
@@ -11,8 +11,8 @@ const STAT: &str = "stat";
 
 /// New struct, not in Python psutil.
 #[allow(dead_code)]
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug)]
 pub struct ProcfsStat {
 	/// PID of the process.

--- a/src/process/process.rs
+++ b/src/process/process.rs
@@ -21,8 +21,8 @@ use crate::{Count, Percent, Pid};
 #[cfg(target_os = "linux")]
 use crate::process::os::linux::ProcfsStat;
 
-// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 // #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Debug)]
 pub struct Process {
 	pub(crate) pid: Pid,

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -2,8 +2,8 @@
 use serde::{Deserialize, Serialize};
 
 /// Possible statuses for a process.
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Clone, Copy, Debug)]
 pub enum Status {
 	/// (R)

--- a/src/sensors/fan_sensor.rs
+++ b/src/sensors/fan_sensor.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::Rpm;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 pub struct FanSensor {
 	pub(crate) _label: String,
 	pub(crate) _current: Rpm,

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,8 +14,8 @@ pub type FloatCount = f64;
 pub type Degrees = FloatCount;
 pub type Mhz = FloatCount;
 
-#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
 #[derive(Debug, Clone)]
 pub struct Temperature {
 	celsius: Degrees,


### PR DESCRIPTION
- fix

```sh
warning: derive helper attribute is used before it is introduced
 --> src/process/status.rs:5:31
  |
5 | #[cfg_attr(feature = "serde", serde(crate = "renamed_serde"))]
  |                               ^^^^^
6 | #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
  |                                      --------- the attribute is introduced here
  |
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
```