### PR TITLE
fix: Add glob as dependency to CPU feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ cfg-if = "1.0.0"
 nix = { version = "0.30.0", default-features = false, features = ["feature", "fs", "signal"] }
 once_cell = "1.2.0"
 thiserror = "2.0.8"
-
 derive_more = { version = "1.0.0", optional = true, default-features = false, features = ["add", "sum"]}
 glob = { version = "0.3.0", optional = true }
 num_cpus = { version = "1.11.1", optional = true }
@@ -35,7 +34,7 @@ default = ["cpu", "disk", "host", "memory", "network", "process", "sensors"]
 serde = ["renamed_serde", "platforms/serde"]
 
 # Modules
-cpu = ["mach2", "num_cpus"]
+cpu = ["mach2", "num_cpus", "glob"]
 disk = ["derive_more", "unescape"]
 host = ["platforms"]
 memory = ["mach2"]


### PR DESCRIPTION
- Add condition to add `glob` only for Linux target OS, as `sensors` and `cpu` modules/features depend on it.

fixes #127